### PR TITLE
Add support for entity fallback renderer

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -55,8 +55,9 @@ export const renderNode = (
   }
   if (node.entity !== null) {
     const entity = entityMap[node.entity];
-    if (entity && entityRenderers[entity.type]) {
-      return entityRenderers[entity.type](
+    const entityRenderer = entity && (entityRenderers[entity.type] || entityRenderers.fallbackRenderer)
+    if (entityRenderer) {
+      return entityRenderer(
         checkJoin(children, options),
         entity.data,
         { key: node.entity, block: node.block },


### PR DESCRIPTION
### Description

Today, redraft renders entities based on an explicit map of the form `entityType : Component`. This model falls short when you want to pass in a component that will render unsupported plugins. Unsupported plugin types are unkown by definition so we can not pass all of their types to a map. 

This PR adds the possibility to pass a `fallbackRenderer` to the map. If passed, the `fallbackRenderer` will render when the `entityType` is not available in the `entityRenderers` map
This is useful if we want to render a plugin with a generic component when there is component registered for that plugin