### PR TITLE
Expose createBlockRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.5
+- expose createBlockRenderer
+
 ## 1.1.4
 - pass entityType to entityRenderer
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wix-redraft",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Based on github.com/lokiuz/redraft. Adjusted for wix-rich-content needs.",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
 import RawParser from './RawParser';
 import createStylesRenderer from './createStyleRenderer';
+import createBlockRenderer from './createBlockRenderer';
 import { renderNode, render } from './render';
 import CompositeDecorator from './helpers/CompositeDecorator';
 
 export {
   createStylesRenderer,
+  createBlockRenderer,
   RawParser,
   renderNode,
   CompositeDecorator,


### PR DESCRIPTION
We rely on createBlockRenderer in mobile which is exposed in later versions of the original library, but not in this fork 